### PR TITLE
Change the way extract Likes and Comments to fit on different languages

### DIFF
--- a/facebook_scraper.py
+++ b/facebook_scraper.py
@@ -21,8 +21,8 @@ _headers = {'User-Agent': _user_agent, 'Accept-Language': 'en-US,en;q=0.5'}
 _session = None
 _timeout = None
 
-_likes_regex = re.compile(r'([0-9,.]+)\s+Like')
-_comments_regex = re.compile(r'([0-9,.]+)\s+Comment')
+_likes_regex = re.compile(r'like_def[^>]*>([0-9,.]+)')
+_comments_regex = re.compile(r'cmt_def[^>]*>([0-9,.]+)')
 _shares_regex = re.compile(r'([0-9,.]+)\s+Shares')
 _link_regex = re.compile(r"href=\"https:\/\/lm\.facebook\.com\/l\.php\?u=(.+?)\&amp;h=")
 
@@ -206,8 +206,7 @@ def _extract_post_url(article):
 
 def _find_and_search(article, selector, pattern, cast=str):
     container = article.find(selector, first=True)
-    text = container and container.text
-    match = text and pattern.search(text)
+    match = pattern.search(container.html)
     return match and cast(match.groups()[0])
 
 


### PR DESCRIPTION
Hi, thanks for maintaining this project.

There is situation that despite adding the header
`Accept-Language: en-US,en;q=0.5`
, it still returns the language of my country (Taiwan).

So, I think it would be more appropriate to extract with the `class` attribute in the `footer` of each `article`.

I tested it with Taiwan IP and Japan IP (response language: English) .

Let me know if you are interested : )

---
By the way, I want to ask if you know there are two different UI on mobile version of Facebook website that one with javascript and one not depending on which `User-Agent` being used.
