### PR TITLE
Modify _photo_link regex to better capture high quality images

### DIFF
--- a/facebook_scraper.py
+++ b/facebook_scraper.py
@@ -29,7 +29,7 @@ _link_regex = re.compile(r"href=\"https:\/\/lm\.facebook\.com\/l\.php\?u=(.+?)\&
 _cursor_regex = re.compile(r'href:"(/page_content[^"]+)"')  # First request
 _cursor_regex_2 = re.compile(r'href":"(\\/page_content[^"]+)"')  # Other requests
 
-_photo_link = re.compile(r"<a href=\"(/[^\"]+/photos/[^\"]+?)\"")
+_photo_link = re.compile(r"href=\"(/[^\"]+/photos/[^\"]+?)\"")
 _image_regex = re.compile(
     r"<a href=\"([^\"]+?)\" target=\"_blank\" class=\"sec\">View Full Size<\/a>"
 )


### PR DESCRIPTION
Small change to the _photo_link regex.  A class attribute gets inserted between the a tag and the href attribute in the photo links, causing the current regex to miss them.  Removing the leading "<a " and searching for just the href seems to fix it.