### PR TITLE
No empty return for groups

### DIFF
--- a/facebook_scraper.py
+++ b/facebook_scraper.py
@@ -184,6 +184,8 @@ def _extract_image(article):
 
 def _extract_image_lq(article):
     story_container = article.find('div.story_body_container', first=True)
+    if story_container is None:
+        return None
     other_containers = story_container.xpath('div/div')
 
     for container in other_containers:

--- a/facebook_scraper.py
+++ b/facebook_scraper.py
@@ -65,7 +65,7 @@ def _get_posts(path, pages=10, timeout=5, sleep=0, credentials=None):
 
     _timeout = timeout
     response = _session.get(url, timeout=_timeout)
-    html = response.html
+    html = HTML(html=response.html.html.replace('<!--','').replace('-->',''))
     cursor_blob = html.html
 
     while True:


### PR DESCRIPTION
It looks like facebook is putting part of the content of the page inside comments, and this confuses html-requests' parser.
This CL strips the comments away

Fixes #18 
Fixes #19 
Fixes #27 