### PR TITLE
Improved Facebook video post URL extraction support

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -47,7 +47,7 @@ class PostExtractor:
     image_regex_lq = re.compile(r"background-image: url\('(.+)'\)")
     video_thumbnail_regex = re.compile(r"background: url\('(.+)'\)")
     post_url_regex = re.compile(r'/story.php\?story_fbid=')
-    video_post_url_regex = re.compile(r'https://www.facebook.com/\w+/videos/.+/')
+    video_post_url_regex = re.compile(r'https://www.facebook.com/.+/videos/.+/(.+)/.+')
 
     shares_and_reactions_regex = re.compile(
         r'<script nonce=.*>.*bigPipe.onPageletArrive\((?P<data>\{.*RelayPrefetchedStreamCache.*\})\);'
@@ -231,14 +231,19 @@ class PostExtractor:
         elements = self.element.find('header a')
         for element in elements:
             href = element.attrs.get('href', '')
+
             post_match = self.post_url_regex.match(href)
+            video_post_match = self.video_post_url_regex.match(href)
+
             if post_match:
                 path = utils.filter_query_params(href, whitelist=query_params)
                 url = utils.urljoin(FB_MOBILE_BASE_URL, path)
                 return {'post_url': url}
-            elif self.video_post_url_regex.match(href):
-                clean_url = utils.filter_query_params(href, whitelist=query_params)
-                return {'post_url': clean_url}
+
+            elif video_post_match:
+                video_post_id = video_post_match.group(1)
+                url = utils.urljoin(FB_MOBILE_BASE_URL, f'watch/?v={video_post_id}')
+                return {'post_url': url}
         return None
 
     # TODO: Remove `or 0` from this methods


### PR DESCRIPTION
This PR is in a addition to #98.
It adds support for shorter video post URLs.

For example:

Instead of getting the following URL for a video post: https://www.facebook.com/ayelet.benshaul.shaked/videos/%D7%A0%D7%A1%D7%95-%D7%9C%D7%A2%D7%A0%D7%95%D7%AA-%D7%9C%D7%A2%D7%A6%D7%9E%D7%9B%D7%9D-%D7%9E%D7%94-%D7%90%D7%AA%D7%9D-%D7%A8%D7%95%D7%90%D7%99%D7%9D-%D7%A9%D7%A7%D7%95%D7%A8%D7%94-%D7%9B%D7%90%D7%9F/838037526723792/?__tn__=-R

You will get a much shorter URL, representing the same video post:
https://m.facebook.com/watch/?v=838037526723792