### PR TITLE
Extract video post URL ID without Facebook URL

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -47,7 +47,7 @@ class PostExtractor:
     image_regex_lq = re.compile(r"background-image: url\('(.+)'\)")
     video_thumbnail_regex = re.compile(r"background: url\('(.+)'\)")
     post_url_regex = re.compile(r'/story.php\?story_fbid=')
-    video_post_url_regex = re.compile(r'https://www.facebook.com/.+/videos/.+/(.+)/.+')
+    video_post_url_regex = re.compile(r'/.+/videos/.+/(.+)/.+')
 
     shares_and_reactions_regex = re.compile(
         r'<script nonce=.*>.*bigPipe.onPageletArrive\((?P<data>\{.*RelayPrefetchedStreamCache.*\})\);'


### PR DESCRIPTION
Before this change, extracting a video post URL failed due to a server-side Facebook change.