### PR TITLE
Added fallback time extraction engine

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from json import JSONDecodeError
 from typing import Any, Dict, Optional
 
+import dateparser
+
 from . import utils
 from .constants import FB_BASE_URL, FB_MOBILE_BASE_URL
 from .fb_types import RawPost, Options, Post, RequestFunction
@@ -38,6 +40,7 @@ class PostExtractor:
     comments_regex = re.compile(r'cmt_def[^>]*>([0-9,.]+)')
     shares_regex = re.compile(r'([0-9,.]+)\s+Shares', re.IGNORECASE)
     link_regex = re.compile(r"href=\"https:\/\/lm\.facebook\.com\/l\.php\?u=(.+?)\&amp;h=")
+    time_regex = re.compile(r"(\w+ \d{2} at \d{2}:\d{2} (AM|PM))|(\d{1,2} \w+)")
 
     photo_link = re.compile(r'href=\"(/[^\"]+/photos/[^\"]+?)\"')
     image_regex = re.compile(
@@ -203,7 +206,16 @@ class PostExtractor:
             except (KeyError, ValueError):
                 continue
 
-        return None
+        try:
+            time_match = self.time_regex.search(self.element.full_text)
+            if time_match:
+                time = time_match.group(0)
+                return {
+                    # 'time': datetime.strptime(time, '%B %d at %I:%M %p').replace(year=datetime.now().year),
+                    'time': dateparser.parse(time)
+                }
+        except:
+            return None
 
     def extract_user_id(self) -> PartialPost:
         return {'user_id': self.data_ft['content_owner_id_new']}

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -211,11 +211,12 @@ class PostExtractor:
             if time_match:
                 time = time_match.group(0)
                 return {
-                    # 'time': datetime.strptime(time, '%B %d at %I:%M %p').replace(year=datetime.now().year),
                     'time': dateparser.parse(time)
                 }
         except:
             return None
+
+        return None
 
     def extract_user_id(self) -> PartialPost:
         return {'user_id': self.data_ft['content_owner_id_new']}

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -203,14 +203,11 @@ class PostExtractor:
             except (KeyError, ValueError):
                 continue
 
-        try:
-            date = utils.parse_date(element_full_text=self.element.full_text)
-            if date:
-                return {
-                    'time': date
-                }
-        except:
-            return None
+        date = utils.parse_date(element_full_text=self.element.full_text)
+        if date:
+            return {
+                'time': date
+            }
 
         return None
 

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -203,7 +203,7 @@ class PostExtractor:
             except (KeyError, ValueError):
                 continue
 
-        date = utils.parse_date(element_full_text=self.element.full_text)
+        date = utils.parse_datetime(element_full_text=self.element.full_text)
         if date:
             return {
                 'time': date

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -6,8 +6,6 @@ from datetime import datetime
 from json import JSONDecodeError
 from typing import Any, Dict, Optional
 
-import dateparser
-
 from . import utils
 from .constants import FB_BASE_URL, FB_MOBILE_BASE_URL
 from .fb_types import RawPost, Options, Post, RequestFunction
@@ -40,7 +38,6 @@ class PostExtractor:
     comments_regex = re.compile(r'cmt_def[^>]*>([0-9,.]+)')
     shares_regex = re.compile(r'([0-9,.]+)\s+Shares', re.IGNORECASE)
     link_regex = re.compile(r"href=\"https:\/\/lm\.facebook\.com\/l\.php\?u=(.+?)\&amp;h=")
-    time_regex = re.compile(r"(\w+ \d{2} at \d{2}:\d{2} (AM|PM))|(\d{1,2} \w+)")
 
     photo_link = re.compile(r'href=\"(/[^\"]+/photos/[^\"]+?)\"')
     image_regex = re.compile(
@@ -207,11 +204,10 @@ class PostExtractor:
                 continue
 
         try:
-            time_match = self.time_regex.search(self.element.full_text)
-            if time_match:
-                time = time_match.group(0)
+            date = utils.parse_date(element_full_text=self.element.full_text)
+            if date:
                 return {
-                    'time': dateparser.parse(time)
+                    'time': date
                 }
         except:
             return None

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -66,7 +66,7 @@ date = f"(?:{month}) " + r"\d{1,2}" + r"(?:, \d{4})?"
 hour = r"\d{1,2}"
 minute = r"\d{2}"
 period = r"AM|PM"
-exact_time = f"({date}) at {hour}:{minute} ({period})"
+exact_time = f"(?:{date}) at {hour}:{minute} (?:{period})"
 relative_time = r"\b\d{1,2}(?:h| hrs)"
 
 datetime_regex = re.compile(fr"({exact_time}|{relative_time})")

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -1,7 +1,10 @@
 import codecs
 import re
+from datetime import datetime
+from typing import Optional
 from urllib.parse import parse_qsl, unquote, urlencode, urljoin, urlparse, urlunparse
 
+import dateparser
 from html2text import html2text as _html2text
 from requests_html import DEFAULT_URL, Element, PyQuery
 
@@ -43,3 +46,35 @@ def make_html_element(html: str, url=DEFAULT_URL) -> Element:
 
 def html2text(html: str) -> str:
     return _html2text(html)
+
+
+date = r"Jan(?:uary)?|" \
+       r"Feb(?:ruary)?|" \
+       r"Mar(?:ch)?|" \
+       r"Apr(?:il)?|" \
+       r"May|" \
+       r"Jun(?:e)?|" \
+       r"Jul(?:y)?|" \
+       r"Aug(?:ust)?|" \
+       r"Sep(?:tember)?|" \
+       r"Oct(?:ober)?|" \
+       r"Nov(?:ember)?|" \
+       r"Dec(?:ember)?|" \
+       r"Yesterday|" \
+       r"Today"
+hour = r"\d{1,2}"
+minute = r"\d{2}"
+period = r"AM|PM"
+exact_time = fr"({date}) at {hour}:{minute} ({period})"
+relative_time = r"\d{1,2} \w+"
+
+time_regex = re.compile(fr"({exact_time}|{relative_time})")
+
+
+def parse_date(element_full_text: str) -> Optional[datetime]:
+    time_match = time_regex.search(element_full_text)
+    if time_match:
+        time = time_match.group(0)
+        return dateparser.parse(time)
+    else:
+        return None

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -48,24 +48,25 @@ def html2text(html: str) -> str:
     return _html2text(html)
 
 
-date = r"Jan(?:uary)?|" \
-       r"Feb(?:ruary)?|" \
-       r"Mar(?:ch)?|" \
-       r"Apr(?:il)?|" \
-       r"May|" \
-       r"Jun(?:e)?|" \
-       r"Jul(?:y)?|" \
-       r"Aug(?:ust)?|" \
-       r"Sep(?:tember)?|" \
-       r"Oct(?:ober)?|" \
-       r"Nov(?:ember)?|" \
-       r"Dec(?:ember)?|" \
-       r"Yesterday|" \
-       r"Today"
+month = r"Jan(?:uary)?|" \
+        r"Feb(?:ruary)?|" \
+        r"Mar(?:ch)?|" \
+        r"Apr(?:il)?|" \
+        r"May|" \
+        r"Jun(?:e)?|" \
+        r"Jul(?:y)?|" \
+        r"Aug(?:ust)?|" \
+        r"Sep(?:tember)?|" \
+        r"Oct(?:ober)?|" \
+        r"Nov(?:ember)?|" \
+        r"Dec(?:ember)?|" \
+        r"Yesterday|" \
+        r"Today"
+date = f"({month}) " + r"\d{1,2}"
 hour = r"\d{1,2}"
 minute = r"\d{2}"
 period = r"AM|PM"
-exact_time = fr"({date}) at {hour}:{minute} ({period})"
+exact_time = f"({date}) at {hour}:{minute} ({period})"
 relative_time = r"\d{1,2} \w+"
 
 time_regex = re.compile(fr"({exact_time}|{relative_time})")

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -62,7 +62,7 @@ month = r"Jan(?:uary)?|" \
         r"Dec(?:ember)?|" \
         r"Yesterday|" \
         r"Today"
-date = f"({month}) " + r"\d{1,2}"
+date = f"(?:{month}) " + r"\d{1,2}" + r"(?:, \d{4})?"
 hour = r"\d{1,2}"
 minute = r"\d{2}"
 period = r"AM|PM"

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -69,11 +69,11 @@ period = r"AM|PM"
 exact_time = f"({date}) at {hour}:{minute} ({period})"
 relative_time = r"\d{1,2} \w+"
 
-time_regex = re.compile(fr"({exact_time}|{relative_time})")
+datetime_regex = re.compile(fr"({exact_time}|{relative_time})")
 
 
-def parse_date(element_full_text: str) -> Optional[datetime]:
-    time_match = time_regex.search(element_full_text)
+def parse_datetime(element_full_text: str) -> Optional[datetime]:
+    time_match = datetime_regex.search(element_full_text)
     if time_match:
         time = time_match.group(0)
         return dateparser.parse(time)

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -67,7 +67,7 @@ hour = r"\d{1,2}"
 minute = r"\d{2}"
 period = r"AM|PM"
 exact_time = f"({date}) at {hour}:{minute} ({period})"
-relative_time = r"\d{1,2} \w+"
+relative_time = r"\b\d{1,2}(?:h| hrs)"
 
 datetime_regex = re.compile(fr"({exact_time}|{relative_time})")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -223,3 +223,4 @@ yarl==1.4.2; python_version >= "3.6" \
 zipp==3.1.0; python_version < "3.8" \
     --hash=sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b \
     --hash=sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96
+dateparser~=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,3 +92,7 @@ websockets==8.0.2 \
     --hash=sha256:f5cb2683367e32da6a256b60929a3af9c29c212b5091cf5bace9358d03011bf5 \
     --hash=sha256:049e694abe33f8a1d99969fee7bfc0ae6761f7fd5f297c58ea933b27dd6805f2 \
     --hash=sha256:882a7266fa867a2ebb2c0baaa0f9159cabf131cf18c1b4270d79ad42f9208dc5
+
+html2text~=2020.1.16
+requests~=2.24.0
+dateparser~=1.0.0


### PR DESCRIPTION
Solves #134, where for some reason time is not always correctly extracted, therefore I have added a fallback way of extracting time (if the current one fails), by trying to extract it from the element's text.

As of right now, it successfully works with two different type of dates:
Example 1: `October 28 11:58 AM`
Example 2: `9 hrs` (9 hours ago, the example was only tested with hours)

The engine uses the following regex:
`(\w+ \d{2} at \d{2}:\d{2} (AM|PM))|(\d{1,2} \w+)`
with a segment for example 1 (`\w+ \d{2} at \d{2}:\d{2} (AM|PM)`) and for example 2 (`(\d{1,2} \w+`).

In order to easily parse dates, I have added a dependency on the package `dateparser` (added to `requirements.txt` and `requirements-dev.txt`)

Even though not all example of dates have been tested yet, the regex will probably be able to extract the different undiscovered date templates and let the date parser parse it automatically.