### PR TITLE
Yesterday/Today are instead of month+dayofmonth and not just instead …

### DIFF
--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -57,14 +57,17 @@ month = (
     r"Sep(?:tember)?|"
     r"Oct(?:ober)?|"
     r"Nov(?:ember)?|"
-    r"Dec(?:ember)?|"
-    r"Yesterday|"
-    r"Today"
+    r"Dec(?:ember)?"
 )
-date = f"(?:{month}) " + r"\d{1,2}" + r"(?:, \d{4})?"
+day_of_month = r"\d{1,2}"
+specific_date = f"(?:{month}) {day_of_month}" + r" (?:, \d{4})?"
+
+date = f"{specific_date}|Today|Yesterday"
+
 hour = r"\d{1,2}"
 minute = r"\d{2}"
 period = r"AM|PM"
+
 exact_time = f"(?:{date}) at {hour}:{minute} (?:{period})"
 relative_time = r"\b\d{1,2}(?:h| hrs)"
 

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -60,7 +60,7 @@ month = (
     r"Dec(?:ember)?"
 )
 day_of_month = r"\d{1,2}"
-specific_date = f"(?:{month}) {day_of_month}" + r" (?:, \d{4})?"
+specific_date = f"(?:{month}) {day_of_month}" + r"(?:, \d{4})?"
 
 date = f"{specific_date}|Today|Yesterday"
 

--- a/tests/test_parse_date.py
+++ b/tests/test_parse_date.py
@@ -1,0 +1,39 @@
+import pytest
+
+from facebook_scraper.utils import parse_datetime
+
+
+@pytest.mark.vcr()
+class TestParseDate:
+    dates = [
+        'Oct 1 at 1:00 PM',
+        'Oct 1 at 11:00 PM',
+        'Oct 16 at 1:00 PM',
+        'Oct 16 at 11:00 PM',
+        'October 1 at 1:00 PM',
+        'October 1 at 11:00 PM',
+        'October 16 at 1:00 PM',
+        'October 16 at 11:00 PM',
+        'October 1, 2019 at 1:00 PM',
+        'October 1, 2019 at 11:00 PM',
+        'October 16, 2019 at 1:00 PM',
+        'October 16, 2019 at 11:00 PM',
+        'Yesterday at 1:00 PM',
+        'Yesterday at 11:00 PM',
+        'Today at 1:00 PM',
+        'Today at 11:00 PM',
+        'Yesterday at 1:00 PM',
+        'Yesterday at 11:00 PM',
+        '1h',
+        '16h',
+        '1hrs',
+        '16hrs'
+    ]
+
+    def test_all_dates(self):
+        for date in self.dates:
+            try:
+                assert parse_datetime(date) is not None
+            except AssertionError as e:
+                print(f'Failed to parse {date}')
+                raise e


### PR DESCRIPTION
Fixes a bug in #135 where 'Yesterday' or 'Today' dates are equivalent to November\December and must be followed with a day-of-month digit.

This relative day specification is not equivalent to month and day-of-month.