### PR TITLE
Added 'is_live' and improved URL extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Note: If you get a `UnicodeEncodeError` try adding `--encoding utf-8`.
  'reactions': {'like': 135, 'love': 64, 'haha': 10, 'wow': 4, 'anger': 1},  # if `extra_info` was set
  'post_url': 'https://m.facebook.com/story.php'
              '?story_fbid=2257188721032235&id=119240841493711',
- 'link': 'https://bit.ly/something'
+ 'link': 'https://bit.ly/something', 
  'is_live': False}
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Note: If you get a `UnicodeEncodeError` try adding `--encoding utf-8`.
  'reactions': {'like': 135, 'love': 64, 'haha': 10, 'wow': 4, 'anger': 1},  # if `extra_info` was set
  'post_url': 'https://m.facebook.com/story.php'
              '?story_fbid=2257188721032235&id=119240841493711',
- 'link': 'https://bit.ly/something'}
+ 'link': 'https://bit.ly/something'
+ 'is_live': False}
 ```
 
 

--- a/facebook_scraper/__init__.py
+++ b/facebook_scraper/__init__.py
@@ -44,7 +44,7 @@ def get_posts(
 
     _scraper.requests_kwargs['timeout'] = kwargs.pop('timeout', DEFAULT_REQUESTS_TIMEOUT)
 
-    options = kwargs.setdefault('options', set())
+    options = kwargs.setdefault('options', {'account': account})
 
     # TODO: Add a better throttling mechanism
     if 'sleep' in kwargs:

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -38,6 +38,7 @@ class PostExtractor:
     likes_regex = re.compile(r'like_def[^>]*>([0-9,.]+)')
     comments_regex = re.compile(r'cmt_def[^>]*>([0-9,.]+)')
     shares_regex = re.compile(r'([0-9,.]+)\s+Shares', re.IGNORECASE)
+    live_regex = re.compile(r'.+(is live).+')
     link_regex = re.compile(r"href=\"https:\/\/lm\.facebook\.com\/l\.php\?u=(.+?)\&amp;h=")
 
     photo_link = re.compile(r'href=\"(/[^\"]+/photos/[^\"]+?)\"')
@@ -85,6 +86,7 @@ class PostExtractor:
             'link': None,
             'user_id': None,
             'source': None,
+            'is_live': False
         }
 
     def extract_post(self) -> Post:
@@ -104,6 +106,7 @@ class PostExtractor:
             self.extract_video,
             self.extract_video_thumbnail,
             self.extract_video_id,
+            self.extract_is_live
         ]
 
         post = self.make_new_post()
@@ -425,6 +428,16 @@ class PostExtractor:
         if match:
             return {'video_id': match.groups()[0]}
         return None
+
+    def extract_is_live(self):
+        header = self.element.find('header')[0].full_text
+
+        match = self.live_regex.search(header)
+
+        if match is not None:
+            return {'is_live': True}
+
+        return {'is_live': False}
 
     def parse_share_and_reactions(self, html: str):
         bad_jsons = self.shares_and_reactions_regex.findall(html)


### PR DESCRIPTION
This changes:

 - [x] Replace old post url (`https://facebook.com/story.php?....` which opened the mobile website) with `https://facebook.com/account/posts/23232323`.
 - [x] Replace old video url (`https://facebook.com/watch?v=232312312`) with `https://facebook.com/account/videos/232312312`
 
 - [x] Detect whether a post is an ongoing live video (judging by the text 'x is live since 1h' that is in the header node).
 

Note: The old url extraction engines are implemented as a fallback engine if for some reason the new engine fails.