### PR TITLE
Extract factcheck information from posts

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -88,6 +88,7 @@ class PostExtractor:
             'username': None,
             'source': None,
             'is_live': False,
+            'factcheck': None
         }
 
     def extract_post(self) -> Post:
@@ -109,6 +110,7 @@ class PostExtractor:
             self.extract_video_thumbnail,
             self.extract_video_id,
             self.extract_is_live,
+            self.extract_factcheck
         ]
 
         post = self.make_new_post()
@@ -453,6 +455,18 @@ class PostExtractor:
             return {'is_live': True}
 
         return {'is_live': False}
+
+    def extract_factcheck(self):
+        button = self.element.find('button[value="See Why"]', first=True)
+        if not button:
+            return None
+        factcheck_div = button.element.getparent().getparent()
+        factcheck = ""
+        for text in factcheck_div.itertext():
+            if text.strip() == "See Why":
+                continue
+            factcheck += text + "\n"
+        return {'factcheck': factcheck}
 
     def parse_share_and_reactions(self, html: str):
         bad_jsons = self.shares_and_reactions_regex.findall(html)


### PR DESCRIPTION
This PR adds an extract function to get the text describing any fact checking result attached to a post. Such functionality would likely be very useful for researchers investigating the spread or extent of misinformation on Facebook.

Sample results:

```
{'comments': 0,
  'factcheck': 'False information\n'
               'The same information was checked in another post by '
               'independent fact-checkers\n',
  'image': None,
  'images': [],
  'is_live': False,
  'likes': 0,
  'link': None,
  'post_id': None,
  'post_text': '',
  'post_url': 'https://facebook.com/story.php?story_fbid=797551657505964&id=100017534100813',
  'shared_text': '',
  'shares': 0,
  'text': '',
  'time': datetime.datetime(2021, 3, 2, 10, 3),
  'user_id': None,
  'username': 'Debz Elaine',
  'video': None,
  'video_id': None,
  'video_thumbnail': None}
```

Or

```
{'comments': 70,
  'factcheck': 'Missing context. \n'
               'The same information was checked in another post by '
               'independent fact-checkers.\n',
  'image': 'https://scontent.fakl1-2.fna.fbcdn.net/v/t1.0-9/fr/cp0/e15/q65/156087569_258963795881177_7275140863968872515_n.jpg?_nc_cat=102&ccb=1-3&_nc_sid=110474&_nc_ohc=1r8k3NVTUnkAX-4nlIe&_nc_ht=scontent.fakl1-2.fna&tp=14&oh=a8a7a7ab3ce6cad1b23d26e254e77b1d&oe=6069298E',
  'images': ['https://scontent.fakl1-2.fna.fbcdn.net/v/t1.0-9/fr/cp0/e15/q65/156087569_258963795881177_7275140863968872515_n.jpg?_nc_cat=102&ccb=1-3&_nc_sid=110474&_nc_ohc=1r8k3NVTUnkAX-4nlIe&_nc_ht=scontent.fakl1-2.fna&tp=14&oh=a8a7a7ab3ce6cad1b23d26e254e77b1d&oe=6069298E'],
  'is_live': False,
  'likes': 149,
  'link': None,
  'post_id': '258963819214508',
  'post_text': 'This just in from Israel showing how the Government of Israel '
               'is setting up for persecution and isolation of those who do '
               'not wish to be part of a clinical trial. Prominent Doctors in '
               'Israel are now starting to speak up about the negative '
               'impacts. Equally as important is this new form of apartheid & '
               'persecution that is coming - WHO would have thought? (Pun '
               'intended). We will not consent to this in Aotearoa New '
               "Zealand'.",
  'post_url': 'https://facebook.com/BillyTeKahikaofficial/posts/258963819214508',
  'shared_text': '',
  'shares': 0,
  'text': 'This just in from Israel showing how the Government of Israel is '
          'setting up for persecution and isolation of those who do not wish '
          'to be part of a clinical trial. Prominent Doctors in Israel are now '
          'starting to speak up about the negative impacts. Equally as '
          'important is this new form of apartheid & persecution that is '
          'coming - WHO would have thought? (Pun intended). We will not '
          "consent to this in Aotearoa New Zealand'.",
  'time': datetime.datetime(2021, 3, 7, 13, 9, 55),
  'user_id': '106260534484838',
  'username': 'Billy Te Kahika',
  'video': None,
  'video_id': None,
  'video_thumbnail': None}
```