### PR TITLE
Extract shared post information

### DIFF
--- a/facebook_scraper/page_iterators.py
+++ b/facebook_scraper/page_iterators.py
@@ -66,7 +66,7 @@ class PageParser:
 
     def get_page(self) -> Page:
         raw_page = self.get_raw_page()
-        raw_posts = raw_page.find('article')
+        raw_posts = raw_page.find('article[data-ft]') # Select only articles that have the data-ft attribute
 
         if not raw_posts:
             logger.warning("No raw posts (<article> elements) were found in this page.")


### PR DESCRIPTION
This PR adds an extract function to extract information about the original post in the case of a re-shared post.

Also of note - currently, when the scraper sees a post that is a re-share of a different post, the scraper returns two separate posts, one for the top level article element, and one for the article element contained within. The second level article element has post_id and user_id set to None, as the HTML is different (it doesn't have the data-ft attribute). This bug is solved by adjusting the selector to `article[data-ft]`.

This fix should make it so that every post has a post_id, which would enable deduplication of posts based on post_id.

Sample output:

```
{'comments': 0,
 'factcheck': None,
 'image': None,
 'images': [],
 'is_live': False,
 'likes': 0,
 'link': None,
 'post_id': '3838780286243316',
 'post_text': '',
 'post_url': 'https://facebook.com/The-Alien-427012304086815/posts/3838780286243316',
 'shared_post_id': '10157430093782100',
 'shared_post_url': 'https://facebook.com/story.php?story_fbid=10157430093782100&id=684282099',
 'shared_text': 'Keith Bennett\n'
                '7 March at 18:29 ·\n'
                '\n'
                'the second most prevalent liquid on earth apparently 🧐🤩🤭🤔',
 'shared_time': datetime.datetime(2021, 3, 7, 18, 29),
 'shared_user_id': 684282099,
 'shared_username': 'Keith Bennett',
 'shares': 0,
 'text': 'Keith Bennett\n'
         '7 March at 18:29 ·\n'
         '\n'
         'the second most prevalent liquid on earth apparently 🧐🤩🤭🤔',
 'time': datetime.datetime(2021, 3, 7, 19, 5),
 'user_id': '427012304086815',
 'username': 'The Alien',
 'video': 'https://video.fakl1-2.fna.fbcdn.net/v/t42.1790-2/156583638_1538691009656188_1459025609004610443_n.mp4?_nc_cat=102&ccb=1-3&_nc_sid=985c63&efg=eyJ2ZW5jb2RlX3RhZyI6InN2ZV9zZCJ9&_nc_ohc=16ZVYsW9LZwAX8NDTi9&_nc_ht=video.fakl1-2.fna&oh=8dafd34edff9fbcb1bec18af359bb0e3&oe=604AFE19',
 'video_id': '10157430093302100',
 'video_thumbnail': 'https://scontent.fakl1-2.fna.fbcdn.net/v/t15.5256-10/cp0/e15/q65/p320x320/121903579_10157430095657100_6547764051614164087_n.jpg?_nc_cat=102&ccb=1-3&_nc_sid=ccf8b3&efg=eyJpIjoidCJ9&_nc_ohc=BWDrHliK8woAX-rth2V&_nc_ht=scontent.fakl1-2.fna&tp=3&oh=43a81206e22a05ac3fcd36d563de2f1f&oe=6071C35D'}
{'comments': 0,
 'factcheck': 'False information\n'
              'The same information was checked in another post by independent '
              'fact-checkers\n',
 'image': None,
 'images': [],
 'is_live': False,
 'likes': 0,
 'link': None,
 'post_id': '3827632707358074',
 'post_text': '',
 'post_url': 'https://facebook.com/The-Alien-427012304086815/posts/3827632707358074',
 'shared_post_id': '797551657505964',
 'shared_post_url': 'https://facebook.com/story.php?story_fbid=797551657505964&id=100017534100813',
 'shared_text': 'Debz Elaine\n2 March at 23:03 ·',
 'shared_time': datetime.datetime(2021, 3, 2, 23, 3),
 'shared_user_id': '100017534100813',
 'shared_username': 'Debz Elaine',
 'shares': 0,
 'text': 'Debz Elaine\n2 March at 23:03 ·',
 'time': datetime.datetime(2021, 3, 3, 8, 36),
 'user_id': '427012304086815',
 'username': 'The Alien',
 'video': None,
 'video_id': None,
 'video_thumbnail': None}
```