### PR TITLE
Ability to get specific posts by url

### DIFF
--- a/facebook_scraper/__init__.py
+++ b/facebook_scraper/__init__.py
@@ -21,6 +21,7 @@ _scraper = FacebookScraper()
 def get_posts(
     account: Optional[str] = None,
     group: Union[str, int, None] = None,
+    post_urls: Optional[Iterator[str]] = None,
     credentials: Optional[Credentials] = None,
     **kwargs,
 ) -> Iterator[Post]:
@@ -29,6 +30,7 @@ def get_posts(
     Args:
         account (str): The account of the page.
         group (int): The group id.
+        post_urls ([str]): List of manually specified post URLs.
         credentials (Optional[Tuple[str, str]]): Tuple of email and password to login before scraping.
         timeout (int): Timeout for requests.
         page_limit (int): How many pages of posts to go through.
@@ -41,10 +43,10 @@ def get_posts(
     Yields:
         dict: The post representation in a dictionary.
     """
-    valid_args = sum(arg is not None for arg in (account, group))
+    valid_args = sum(arg is not None for arg in (account, group, post_urls))
 
     if valid_args != 1:
-        raise ValueError("You need to specify either account or group")
+        raise ValueError("You need to specify either account, group, or post_urls")
 
     _scraper.requests_kwargs['timeout'] = kwargs.pop('timeout', DEFAULT_REQUESTS_TIMEOUT)
 
@@ -90,6 +92,9 @@ def get_posts(
 
     elif group is not None:
         return _scraper.get_group_posts(group, **kwargs)
+
+    elif post_urls is not None:
+        return _scraper.get_posts_by_url(post_urls, **kwargs)
 
     raise ValueError('No account nor group')
 

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -155,7 +155,7 @@ class PostExtractor:
         return post
 
     def extract_post_id(self) -> PartialPost:
-        return {'post_id': self.data_ft.get('mf_story_key')}
+        return {'post_id': self.data_ft.get('top_level_post_id')}
 
     def extract_username(self) -> PartialPost:
         username = self.element.find('h3 strong a')

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -53,7 +53,9 @@ class FacebookScraper:
             if not post_url.startswith(FB_MOBILE_BASE_URL):
                 post_url = utils.urljoin(FB_MOBILE_BASE_URL, post_url)
             logger.debug(f"Requesting page from: {post_url}")
-            elem = self.get(post_url).html.find('article[data-ft],div.async_like[data-ft]', first=True)
+            response = self.get(post_url)
+            response.html.html = response.html.html.replace('<!--', '').replace('-->', '')
+            elem = response.html.find('article[data-ft],div.async_like[data-ft]', first=True)
             post = extract_post(elem, request_fn=self.get, options=options)
             if remove_source:
                 post.pop('source', None)

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -8,7 +8,7 @@ from requests import RequestException
 from requests_html import HTMLSession
 
 from . import utils
-from .constants import DEFAULT_PAGE_LIMIT, FB_MOBILE_BASE_URL
+from .constants import DEFAULT_PAGE_LIMIT, FB_MOBILE_BASE_URL, FB_BASE_URL
 from .extractors import extract_group_post, extract_post
 from .fb_types import Post
 from .page_iterators import iter_group_pages, iter_pages
@@ -45,6 +45,19 @@ class FacebookScraper:
     def get_posts(self, account: str, **kwargs) -> Iterator[Post]:
         iter_pages_fn = partial(iter_pages, account=account, request_fn=self.get)
         return self._generic_get_posts(extract_post, iter_pages_fn, **kwargs)
+
+    def get_posts_by_url(self, post_urls, options={}, remove_source=True) -> Iterator[Post]:
+        for post_url in post_urls:
+            if post_url.startswith(FB_BASE_URL):
+                post_url = post_url.replace(FB_BASE_URL, FB_MOBILE_BASE_URL)
+            if not post_url.startswith(FB_MOBILE_BASE_URL):
+                post_url = utils.urljoin(FB_MOBILE_BASE_URL, post_url)
+            logger.debug(f"Requesting page from: {post_url}")
+            elem = self.get(post_url).html.find('article[data-ft],div.async_like[data-ft]', first=True)
+            post = extract_post(elem, request_fn=self.get, options=options)
+            if remove_source:
+                post.pop('source', None)
+            yield post
 
     def get_group_posts(self, group: Union[str, int], **kwargs) -> Iterator[Post]:
         iter_pages_fn = partial(iter_group_pages, group=group, request_fn=self.get)


### PR DESCRIPTION
This PR extends get_posts to add an optional post_urls parameter, expected to be a iterable of strings. These can either be full URLs or just fragments, either in {account}/posts/{post_id} format, or story.php?story_fbid={post_id}&id={user_id} format. If a url starts with FB_BASE_URL, it is replaced by FB_MOBILE_BASE_URL, so URLs can potentially be fed directly from scraper output into scraper input.

Here's some sample usage / test code - all 4 different ways of passing URLs should respond with the same post dictionary:

```
from facebook_scraper import get_posts
post_urls = [
    "https://facebook.com/Nintendo/posts/1914977405326050",
    "Nintendo/posts/1914977405326050",
    "https://m.facebook.com/story.php?story_fbid=1914977405326050&id=285708024919671",
    "story.php?story_fbid=1914977405326050&id=285708024919671"
]
posts = list(get_posts(post_urls=post_urls))
print(f"{len(posts)} posts, {len([post for post in posts if not post['text']])} missing text")
assert all([post["post_id"] == "1914977405326050" for post in posts])
```

This should solve #91 
This should also make debugging issues with specific posts easier