### PR TITLE
alternative photo_link regex

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -255,7 +255,7 @@ class PostExtractor:
 
     def extract_image(self) -> PartialPost:
         image_link = self.extract_photo_link()
-        if image_link is not None:
+        if image_link["image"] is not None:
             return image_link
         return self.extract_image_lq()
 
@@ -270,6 +270,9 @@ class PostExtractor:
             if image_container is None:
                 continue
 
+            src = image_container.attrs.get('src')
+            if src:
+                return {'image': src, 'images': [src]}
             style = image_container.attrs.get('style', '')
             match = self.image_regex_lq.search(style)
             if match:

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -24,6 +24,7 @@ def parse_int(value: str) -> int:
 def decode_css_url(url: str) -> str:
     url = re.sub(r'\\(..) ', r'\\x\g<1>', url)
     url, _ = codecs.unicode_escape_decode(url)
+    url, _ = codecs.unicode_escape_decode(url)
     return url
 
 


### PR DESCRIPTION
This PR adds an alternative regex to match photo links that are like /photo.php instead of /{username}/photos/