### PR TITLE
alternative method for extracting post reactions

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -393,6 +393,21 @@ class PostExtractor:
         url = self.post.get('post_url')
         post_id = self.post.get('post_id')
 
+        reaction_url = f'https://m.facebook.com/ufi/reaction/profile/browser/?ft_ent_identifier={post_id}'
+        resp = self.request(reaction_url)
+        reactions = {}
+        for span in resp.html.find("span[aria-label]"):
+            label = span.attrs.get("aria-label", "")
+            if " people reacted with " in label:
+                reaction_count, reaction_type = label.split(" people reacted with ")
+                reactions[reaction_type.lower()] = int(reaction_count)
+        if reactions:
+            return {
+                'likes': reactions.get("like"),
+                'reactions': reactions,
+                'fetched_time': datetime.now(),
+            }
+
         if url:
             w3_fb_url = utils.urlparse(url)._replace(netloc='www.facebook.com').geturl()
             resp = self.request(w3_fb_url)

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -400,7 +400,7 @@ class PostExtractor:
             label = span.attrs.get("aria-label", "")
             if " people reacted with " in label:
                 reaction_count, reaction_type = label.split(" people reacted with ")
-                reactions[reaction_type.lower()] = int(reaction_count)
+                reactions[reaction_type.lower()] = utils.convert_numeric_abbr(reaction_count)
         if reactions:
             return {
                 'likes': reactions.get("like"),

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -98,6 +98,7 @@ class PostExtractor:
             'shared_post_url': None,
             'available': None,
             'comments_full': None,
+            'reactors': None,
         }
 
     def extract_post(self) -> Post:
@@ -145,7 +146,7 @@ class PostExtractor:
             except Exception as ex:
                 log_warning("Exception while running %s: %r", method.__name__, ex)
 
-        if self.options.get('reactions'):
+        if self.options.get('reactions') or self.options.get('reactors'):
             try:
                 reactions = self.extract_reactions()
             except Exception as ex:
@@ -394,17 +395,66 @@ class PostExtractor:
         post_id = self.post.get('post_id')
 
         reaction_url = f'https://m.facebook.com/ufi/reaction/profile/browser/?ft_ent_identifier={post_id}'
-        resp = self.request(reaction_url)
+        response = self.request(reaction_url)
         reactions = {}
-        for span in resp.html.find("span[aria-label]"):
+
+        # Dict mapping class names to human readable reaction names. Prepopulated in case FB doesn't include them
+        reaction_lookup = {
+            'sx_cbd149': 'Like',
+            'sx_202991': 'Love',
+            'sx_41edbc': 'Care',
+            'sx_0d839a': 'Haha',
+            'sx_2b1a8e': 'Wow',
+            'sx_454e38': 'Angry',
+            'sx_1a0b4b': 'Sad'
+        }
+
+        for span in response.html.find("span[aria-label]"):
             label = span.attrs.get("aria-label", "")
             if " people reacted with " in label:
                 reaction_count, reaction_type = label.split(" people reacted with ")
                 reactions[reaction_type.lower()] = utils.convert_numeric_abbr(reaction_count)
+                if self.options.get("reactors"):
+                    emoji_class = span.find("i", first=True).attrs.get("class")[-1]
+                    reaction_lookup[emoji_class] = reaction_type
+
+        reactors = []
+
+        if self.options.get("reactors"):
+            """Fetch people reacting to an existing post obtained by `get_posts`.
+            Note that this method may raise one more http request per post to get all reactors"""
+            logger.debug("Fetching reactors")
+            elems = list(response.html.find("div#reaction_profile_browser>div"))
+            more = response.html.find("div#reaction_profile_pager a", first=True)
+            if more:
+                url = utils.urljoin(FB_MOBILE_BASE_URL, more.attrs.get("href"))
+                url = url.replace("limit=50", f"limit={1e6}")
+                logger.debug(f"Fetching {url}")
+                response = self.request(url)
+                prefix_length = len('for (;;);')
+                data = json.loads(response.text[prefix_length:])  # Strip 'for (;;);'
+
+                for action in data['payload']['actions']:
+                    if action['cmd'] == 'append':
+                        html = utils.make_html_element(f"<div id='reaction_profile_browser'>{action['html']}</div>", url=FB_MOBILE_BASE_URL)
+                        more_elems = html.find('div#reaction_profile_browser>div')
+                        elems.extend(more_elems)
+            logger.debug(f"Found {len(elems)} reactors")
+            for elem in elems:
+                emoji_class = elem.find("div>i:not(.nub)", first=True).attrs.get("class")[-1]
+                if not reaction_lookup.get(emoji_class):
+                    logger.error(f"Don't know {emoji_class}")
+                reactors.append({
+                    "name": elem.find("strong", first=True).text,
+                    "link": utils.urljoin(FB_BASE_URL, elem.find("a", first=True).attrs.get("href")),
+                    "type": reaction_lookup.get(emoji_class)
+                })
+
         if reactions:
             return {
                 'likes': reactions.get("like"),
                 'reactions': reactions,
+                'reactors': reactors,
                 'fetched_time': datetime.now(),
             }
 

--- a/facebook_scraper/utils.py
+++ b/facebook_scraper/utils.py
@@ -20,6 +20,11 @@ def find_and_search(node, selector, pattern, cast=str):
 def parse_int(value: str) -> int:
     return int(''.join(filter(lambda c: c.isdigit(), value)))
 
+def convert_numeric_abbr(s):
+    mapping = {'k': 1000, 'm': 1e6}
+    if s[-1].isalpha():
+        return int(float(s[:-1]) * mapping[s[-1].lower()])
+    return int(s)
 
 def decode_css_url(url: str) -> str:
     url = re.sub(r'\\(..) ', r'\\x\g<1>', url)


### PR DESCRIPTION
This PR adds an alternative method for extracting post reactions, using m.facebook. If this fails for any reason, the existing w3 method is also attempted. Note that this seems more reliable if cookies are passed.

Test code:

```python
posts = list(get_posts("Nintendo", pages=2, extra_info=True, cookies="cookies.txt"))
for post in posts:
  print(post["post_id"], post.get("reactions"))
```

Sample output:

```python
3994908647260225 {'like': 168, 'love': 19, 'care': 4, 'angry': 3}
3994422230642200 {'like': 2200, 'love': 774, 'sad': 433, 'care': 83, 'angry': 68, 'haha': 43, 'wow': 11}
3981270225290734 {'like': 5600, 'love': 2300, 'care': 246, 'wow': 99, 'sad': 21, 'haha': 10, 'angry': 2}
3978479458903144 {'like': 216, 'love': 57, 'care': 4, 'angry': 3, 'wow': 2}
3977334782350945 {'like': 1400, 'angry': 703, 'love': 459, 'sad': 87, 'wow': 34, 'haha': 22, 'care': 18}
3968858206531936 {'like': 681, 'love': 127, 'wow': 15, 'care': 10, 'haha': 9, 'angry': 7}
```