### PR TITLE
replace backslash in video src URL, nicer warning for get_posts_by_url error

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -427,7 +427,7 @@ class PostExtractor:
     def extract_video_lowres(self, video_data_element):
         try:
             data = json.loads(video_data_element.attrs['data-store'])
-            return {'video': data.get('src')}
+            return {'video': data.get('src').replace("\\", "")}
         except JSONDecodeError as ex:
             logger.error("Error parsing data-store JSON: %r", ex)
         except KeyError:

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -55,6 +55,8 @@ class FacebookScraper:
             logger.debug(f"Requesting page from: {post_url}")
             response = self.get(post_url)
             elem = response.html.find('article[data-ft],div.async_like[data-ft]', first=True)
+            if not elem:
+                logger.warning("No raw posts (<article> elements) were found in this page.")
             post = extract_post(elem, request_fn=self.get, options=options)
             if remove_source:
                 post.pop('source', None)


### PR DESCRIPTION
As discovered in https://github.com/kevinzg/facebook-scraper/issues/196