### PR TITLE
fix for multiple backslashes in pagination URL

### DIFF
--- a/facebook_scraper/page_iterators.py
+++ b/facebook_scraper/page_iterators.py
@@ -116,7 +116,7 @@ class PageParser:
         match = self.cursor_regex_4.search(self.response.text)
         if match:
             value = match.groups()[0]
-            return value.replace('\\/', '/')
+            return re.sub(r'\\+/', '/', value)
 
         return None
 


### PR DESCRIPTION
This commit (https://github.com/kevinzg/facebook-scraper/commit/83d83cf856a7e309d76e4e18ed9c8bb3f11a2bb1) appears to have broken cursor_regex_4 pagination in the case where there are multiple backslashes in the pagination URL. This PR replaces the simple `replace` with regex matching any number of backslashes followed by a slash.

Observed Exception:

```python
Looking for next page URL
Requesting page from: https://m.facebook.com/profile\\/timeline\\/stream\\/?cursor=AQHRGYjCy296tObNn5qM1cbGSsLncjHCxKqBpr08jP957XeJe0_yewNtdxVFOZDmsNhgFDW6FdXVpe7NInDBUTlKaFygyTU3TOZRVrr-Zk6MWoDbKdUEG8Nk4n-J-oY1Dl2C&start_time=-9223372036854775808&profile_id=100003548348402&replace_id=u_0_0_Vg\
Exception while requesting URL: https://m.facebook.com/profile\\/timeline\\/stream\\/?cursor=AQHRGYjCy296tObNn5qM1cbGSsLncjHCxKqBpr08jP957XeJe0_yewNtdxVFOZDmsNhgFDW6FdXVpe7NInDBUTlKaFygyTU3TOZRVrr-Zk6MWoDbKdUEG8Nk4n-J-oY1Dl2C&start_time=-9223372036854775808&profile_id=100003548348402&replace_id=u_0_0_Vg\
Exception: HTTPError('404 Client Error: Not Found for url: https://m.facebook.com/profile%5C%5C/timeline%5C%5C/stream%5C%5C/?cursor=AQHRGYjCy296tObNn5qM1cbGSsLncjHCxKqBpr08jP957XeJe0_yewNtdxVFOZDmsNhgFDW6FdXVpe7NInDBUTlKaFygyTU3TOZRVrr-Zk6MWoDbKdUEG8Nk4n-J-oY1Dl2C&start_time=-9223372036854775808&profile_id=100003548348402&replace_id=u_0_0_Vg%5C')
```