### PR TITLE
add posts_per_page and allow_extra_requests options

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -185,7 +185,7 @@ class PostExtractor:
         element = self.element
 
         has_more = self.more_url_regex.search(element.html)
-        if has_more:
+        if has_more and self.options.get("allow_extra_requests", True):
             match = self.post_story_regex.search(element.html)
             if match:
                 url = utils.urljoin(FB_MOBILE_BASE_URL, match.groups()[0].replace("&amp;", "&"))
@@ -264,9 +264,10 @@ class PostExtractor:
         return {'user_id': self.data_ft['content_owner_id_new']}
 
     def extract_image(self) -> PartialPost:
-        image_link = self.extract_photo_link()
-        if image_link["image"] is not None:
-            return image_link
+        if self.options.get("allow_extra_requests", True):
+            image_link = self.extract_photo_link()
+            if image_link["image"] is not None:
+                return image_link
         return self.extract_image_lq()
 
     def extract_image_lq(self) -> PartialPost:

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -264,10 +264,9 @@ class PostExtractor:
         return {'user_id': self.data_ft['content_owner_id_new']}
 
     def extract_image(self) -> PartialPost:
-        if self.options.get("allow_extra_requests", True):
-            image_link = self.extract_photo_link()
-            if image_link["image"] is not None:
-                return image_link
+        image_link = self.extract_photo_link()
+        if image_link["image"] is not None:
+            return image_link
         return self.extract_image_lq()
 
     def extract_image_lq(self) -> PartialPost:
@@ -360,6 +359,8 @@ class PostExtractor:
         }
 
     def extract_photo_link(self) -> PartialPost:
+        if not self.options.get("allow_extra_requests", True):
+            return None
         images = []
         matches = list(self.photo_link.finditer(self.element.html))
         if not matches:

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -43,7 +43,7 @@ class FacebookScraper:
         self.requests_kwargs = requests_kwargs
 
     def get_posts(self, account: str, **kwargs) -> Iterator[Post]:
-        iter_pages_fn = partial(iter_pages, account=account, request_fn=self.get)
+        iter_pages_fn = partial(iter_pages, account=account, request_fn=self.get, **kwargs)
         return self._generic_get_posts(extract_post, iter_pages_fn, **kwargs)
 
     def get_posts_by_url(self, post_urls, options={}, remove_source=True) -> Iterator[Post]:


### PR DESCRIPTION
This PR adds two new options to `get_posts`, `posts_per_page` and `allow_extra_requests`. `posts_per_page` allows the user to customise the number of posts returned per page, and `allow_extra_requests=False` allows the user to disable making additional requests in the `extract_text` and `extract_image` functions. When combined, these options allow fetching lots of posts, very quickly. Sample usage:

```python
from facebook_scraper import get_posts
import time
start = time.time()
posts = list(get_posts("Nintendo", cookies="cookies.txt", pages=2, timeout=60, options={"allow_extra_requests": False, "posts_per_page": 200}))
print(f"{len(posts)} posts retrieved in {round(time.time() - start, 2)}s")
```

Outputs:

```python
202 posts retrieved in 16.26s
```