### PR TITLE
ability to specify reactor limit. fix max limit to 5000

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -427,8 +427,8 @@ class PostExtractor:
         if reactors_opt:
             """Fetch people reacting to an existing post obtained by `get_posts`.
             Note that this method may raise one more http request per post to get all reactors"""
-            limit = 5000
-            if type(reactors_opt) in [int, float] and reactors_opt < 5000:
+            limit = 3000
+            if type(reactors_opt) in [int, float] and reactors_opt < limit:
                 limit = reactors_opt
             logger.debug(f"Fetching {limit} reactors")
             elems = list(response.html.find("div#reaction_profile_browser>div"))

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -423,15 +423,19 @@ class PostExtractor:
 
         reactors = []
 
-        if self.options.get("reactors"):
+        reactors_opt = self.options.get("reactors")
+        if reactors_opt:
             """Fetch people reacting to an existing post obtained by `get_posts`.
             Note that this method may raise one more http request per post to get all reactors"""
-            logger.debug("Fetching reactors")
+            limit = 5000
+            if type(reactors_opt) in [int, float] and reactors_opt < 5000:
+                limit = reactors_opt
+            logger.debug(f"Fetching {limit} reactors")
             elems = list(response.html.find("div#reaction_profile_browser>div"))
             more = response.html.find("div#reaction_profile_pager a", first=True)
-            if more:
+            if more and limit > 50:
                 url = utils.urljoin(FB_MOBILE_BASE_URL, more.attrs.get("href"))
-                url = url.replace("limit=50", f"limit={1e6}")
+                url = url.replace("limit=50", f"limit={limit - 50}")
                 logger.debug(f"Fetching {url}")
                 response = self.request(url)
                 prefix_length = len('for (;;);')


### PR DESCRIPTION
As per https://github.com/kevinzg/facebook-scraper/issues/223. In the case where a post has lots of reactors, this PR makes it possible to request just the number of reactors that the user wants. For example:

```python
posts = list(get_posts(post_urls=["https://m.facebook.com/VinDiesel/posts/306426417518211"], timeout=60, cookies="cookies.txt", options={"reactors":150}))
print(len(posts[0].get("reactors")))
```

To get just the first 150 reactors.