### PR TITLE
request_url_callback doesn't pass to the iterator when using get_posts() function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# PyCharm
+.idea
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -245,7 +245,7 @@ class FacebookScraper:
         return result
 
     def get_group_posts(self, group: Union[str, int], **kwargs) -> Iterator[Post]:
-        iter_pages_fn = partial(iter_group_pages, group=group, request_fn=self.get)
+        iter_pages_fn = partial(iter_group_pages, group=group, request_fn=self.get, **kwargs)
         return self._generic_get_posts(extract_group_post, iter_pages_fn, **kwargs)
 
     def check_locale(self, response):

--- a/facebook_scraper/page_iterators.py
+++ b/facebook_scraper/page_iterators.py
@@ -30,9 +30,11 @@ def iter_pages(account: str, request_fn: RequestFunction, **kwargs) -> Iterator[
     return generic_iter_pages(start_url, PageParser, request_fn, **kwargs)
 
 
-def iter_group_pages(group: Union[str, int], request_fn: RequestFunction) -> Iterator[Page]:
+def iter_group_pages(group: Union[str, int], request_fn: RequestFunction, **kwargs) -> Iterator[Page]:
     start_url = utils.urljoin(FB_MOBILE_BASE_URL, f'groups/{group}/')
-    return generic_iter_pages(start_url, GroupPageParser, request_fn)
+    del kwargs['start_url']
+
+    return generic_iter_pages(start_url, GroupPageParser, request_fn, **kwargs)
 
 
 def iter_photos(account: str, request_fn: RequestFunction, **kwargs) -> Iterator[Page]:

--- a/facebook_scraper/page_iterators.py
+++ b/facebook_scraper/page_iterators.py
@@ -18,9 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 def iter_pages(account: str, request_fn: RequestFunction, **kwargs) -> Iterator[Page]:
-    start_url = None
-    if "start_url" in kwargs:
-        start_url = kwargs.pop("start_url")
+    start_url = kwargs.pop("start_url", None)
     if not start_url:
         start_url = utils.urljoin(FB_MOBILE_BASE_URL, f'/{account}/posts/')
         try:
@@ -31,9 +29,7 @@ def iter_pages(account: str, request_fn: RequestFunction, **kwargs) -> Iterator[
 
 
 def iter_group_pages(group: Union[str, int], request_fn: RequestFunction, **kwargs) -> Iterator[Page]:
-    start_url = utils.urljoin(FB_MOBILE_BASE_URL, f'groups/{group}/')
-    del kwargs['start_url']
-
+    start_url = kwargs.pop("start_url", utils.urljoin(FB_MOBILE_BASE_URL, f'groups/{group}/'))
     return generic_iter_pages(start_url, GroupPageParser, request_fn, **kwargs)
 
 


### PR DESCRIPTION
Possible fix for an issue reported in the following comment: https://github.com/kevinzg/facebook-scraper/issues/310#issuecomment-853086241

Currently, when you use get_posts() to scrap FB group's posts, you cannot trigger `request_url_callback` which is helpful during restoring the scrapping process after temporarily bans 