### PR TITLE
[Issue] Make sure the very first search page URL is being generated despite passing start_url as None

### DIFF
--- a/facebook_scraper/page_iterators.py
+++ b/facebook_scraper/page_iterators.py
@@ -29,7 +29,11 @@ def iter_pages(account: str, request_fn: RequestFunction, **kwargs) -> Iterator[
 
 
 def iter_group_pages(group: Union[str, int], request_fn: RequestFunction, **kwargs) -> Iterator[Page]:
-    start_url = kwargs.pop("start_url", utils.urljoin(FB_MOBILE_BASE_URL, f'groups/{group}/'))
+    start_url = kwargs.pop("start_url", None)
+
+    if not start_url:
+        start_url = utils.urljoin(FB_MOBILE_BASE_URL, f'/{group}/posts/')
+
     return generic_iter_pages(start_url, GroupPageParser, request_fn, **kwargs)
 
 

--- a/tests/test_get_posts.py
+++ b/tests/test_get_posts.py
@@ -171,6 +171,8 @@ class TestGetGroupPosts:
 
         assert post == expected_post
 
+    # todo: add a case with requesting a group post with start_url=None
+
     def test_smoketest(self):
         list(get_posts(group=117507531664134, pages=2))
 


### PR DESCRIPTION
After my previous PR https://github.com/kevinzg/facebook-scraper/pull/318, it seems like scrapping stopped to work when start_url is None.

This comes from `kwargs.pop()` function which doesn't pull a default value when `start_url` is passed as None explicitly.

Also, there would be cool to cover this case in the tests, so we will be safe next time.