### PR TITLE
Fix: UnboundLocalError filename referenced before assignment

### DIFF
--- a/facebook_scraper/__main__.py
+++ b/facebook_scraper/__main__.py
@@ -139,7 +139,7 @@ def run():
         if args.filename == "-":
             output_file = sys.stdout
         else:
-            output_file = open(filename, 'w', newline='', encoding=encoding)
+            output_file = open(args.filename, 'w', newline='', encoding=encoding)
 
         profile = get_profile(args.account, friends=args.friends, cookies=args.cookies)
 


### PR DESCRIPTION
When running:

```
facebook-scraper --profile PROFILE --filename EXPORT_FILE
```
i got

```
Traceback (most recent call last):
File "/home/user/.virtualenvs/osintgram/bin/facebook-scraper", line 8, in <module>
sys.exit(run())
File "/home/user/.virtualenvs/virtualenvname/python3.8/site-packages/facebook_scraper/__main__.py", line 142, in run
output_file = open(filename, 'w', newline='', encoding=encoding)
UnboundLocalError: local variable 'filename' referenced before assignment
```
I have fixed it. 
