### PR TITLE
Enable debug: default from INFO to DEBUG

### DIFF
--- a/facebook_scraper/__init__.py
+++ b/facebook_scraper/__init__.py
@@ -401,7 +401,7 @@ def write_posts_to_csv(
     output_file.close()
 
 
-def enable_logging(level=logging.INFO):
+def enable_logging(level=logging.DEBUG):
     handler = logging.StreamHandler()
     handler.setLevel(level)
 


### PR DESCRIPTION
Make `enable_logging`  default debug level match the current debug level in all project code.  
Right now you are not using INFO at all.

Another way to resolve this is to move all `logger.debug` to `logger.info`