### PR TITLE
Added latest_date feature when scraping groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ dmypy.json
 *~
 *.swp
 *.swo
+
+# VSCode
+.vscode


### PR DESCRIPTION
When scraping a group with `get_posts` and the `group` parameter, now you can specify a `latest_date` parameter (default `None`) which takes a `str` with ISO format (`yyyy-mm-dd`).

In this case, the scraper, instead of iterate over a finite number of pages, will iterate until the posts reach the date specified. It will verify this detecting _n_ posts with a date below `latest_date` (with an additional param `max_past_limit` with default `5`).