### PR TITLE
hashtag support

### DIFF
--- a/facebook_scraper/__init__.py
+++ b/facebook_scraper/__init__.py
@@ -137,6 +137,7 @@ def get_posts(
     account: Optional[str] = None,
     group: Union[str, int, None] = None,
     post_urls: Optional[Iterator[str]] = None,
+    hashtag: Optional[str] = None,
     credentials: Optional[Credentials] = None,
     **kwargs,
 ) -> Iterator[Post]:
@@ -158,7 +159,7 @@ def get_posts(
     Yields:
         dict: The post representation in a dictionary.
     """
-    valid_args = sum(arg is not None for arg in (account, group, post_urls))
+    valid_args = sum(arg is not None for arg in (account, group, post_urls, hashtag))
 
     if valid_args != 1:
         raise ValueError("You need to specify either account, group, or post_urls")
@@ -201,6 +202,9 @@ def get_posts(
 
     elif group is not None:
         return _scraper.get_group_posts(group, **kwargs)
+
+    elif hashtag is not None:
+        return _scraper.get_posts_by_hashtag(hashtag, **kwargs)
 
     elif post_urls is not None:
         return _scraper.get_posts_by_url(post_urls, **kwargs)

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -44,6 +44,10 @@ def extract_photo_post(
 ) -> Post:
     return PhotoPostExtractor(raw_post, options, request_fn, full_post_html).extract_post()
 
+def extract_hashtag_post(
+    raw_post: RawPost, options: Options, request_fn: RequestFunction, full_post_html=None
+) -> Post:
+    return HashtagPostExtractor(raw_post, options, request_fn, full_post_html).extract_post()
 
 class PostExtractor:
     """Class for Extracting fields from a FacebookPost"""
@@ -229,7 +233,6 @@ class PostExtractor:
 
             except Exception as ex:
                 log_warning("Exception while extracting comments: %r", ex)
-
         return post
 
     def extract_post_id(self) -> PartialPost:
@@ -1282,3 +1285,20 @@ class PhotoPostExtractor(PostExtractor):
             match = re.search(r'ft_ent_identifier=(\d+)', self.full_post_html.html)
             if match:
                 return {"post_id": match.groups()[0]}
+
+class HashtagPostExtractor(PostExtractor):
+    def __init__(self, element, options, request_fn, full_post_html=None):
+        post_id = self.extract_hashtag_post_id(element)
+        if post_id:
+            response = request_fn(post_id)
+            if response:
+                element = response.html.find('[data-ft*="top_level_post_id"]')[0]
+                full_post_html = response.html
+
+        super().__init__(element, options, request_fn, full_post_html)
+
+    def extract_hashtag_post_id(self, element):
+        match = re.search(r'ft_ent_identifier=(\d+)', element.html)
+        if match:
+            return match.groups()[0]
+        return None

--- a/facebook_scraper/page_iterators.py
+++ b/facebook_scraper/page_iterators.py
@@ -9,13 +9,23 @@ from requests.exceptions import HTTPError
 import warnings
 
 from . import utils
-from .constants import FB_MOBILE_BASE_URL
+from .constants import FB_MOBILE_BASE_URL, FB_MBASIC_BASE_URL
+
 from .fb_types import URL, Page, RawPage, RequestFunction, Response
 from . import exceptions
 
 
 logger = logging.getLogger(__name__)
 
+def iter_hashtag_pages(hashtag: str, request_fn: RequestFunction, **kwargs) -> Iterator[Page]:
+    start_url = kwargs.pop("start_url", None)
+    if not start_url:
+        start_url = utils.urljoin(FB_MBASIC_BASE_URL, f'/hashtag/{hashtag}/')
+        try:
+            request_fn(start_url)
+        except Exception as ex:
+            logger.error(ex)
+    return generic_iter_pages(start_url, HashtagPageParser, request_fn, **kwargs)
 
 def iter_pages(account: str, request_fn: RequestFunction, **kwargs) -> Iterator[Page]:
     start_url = kwargs.pop("start_url", None)
@@ -66,6 +76,7 @@ def generic_iter_pages(
 ) -> Iterator[Page]:
     next_url = start_url
 
+    base_url = kwargs.get('base_url', FB_MOBILE_BASE_URL)
     request_url_callback = kwargs.get('request_url_callback')
     while next_url:
         # Execute callback of starting a new URL request
@@ -106,7 +117,7 @@ def generic_iter_pages(
             posts_per_page = kwargs.get("options", {}).get("posts_per_page")
             if posts_per_page:
                 next_page = next_page.replace("num_to_fetch=4", f"num_to_fetch={posts_per_page}")
-            next_url = utils.urljoin(FB_MOBILE_BASE_URL, next_page)
+            next_url = utils.urljoin(base_url, next_page)
         else:
             logger.info("Page parser did not find next page URL")
             next_url = None
@@ -265,3 +276,19 @@ class SearchPageParser(PageParser):
             if match:
                 value = match.groups()[0]
                 return value.encode('utf-8').decode('unicode_escape').replace('\\/', '/')
+
+
+class HashtagPageParser(PageParser):
+    cursor_regex = re.compile(r'(\/hashtag\/[a-z]+\/\?locale=[a-z_A-Z]+&amp;cursor=[^"]+).*$')
+
+    def get_page(self) -> Page:
+        return super()._get_page('article', 'article')
+
+    def get_next_page(self) -> Optional[URL]:
+        assert self.cursor_blob is not None
+
+        match = self.cursor_regex.search(self.cursor_blob)
+        if match:
+            return utils.unquote(match.groups()[0]).replace("&amp;", "&")
+
+        return None


### PR DESCRIPTION
I was following #419 and learn some stuff on how to add hashtags. 

On https://github.com/kevinzg/facebook-scraper/issues/419#issuecomment-981998345 i pointed out that hashtags are not supported on m.facebook.com. 

I have added:
- get_posts_by_hashtag
- get_posts support for that

How to use it?
```
posts = get_posts(hashtag="hola", cookies=cookies_file, pages=2, options=options)
```

Facts:

I am using `mbasic.facebook.com` to iterate over page, but to use posts extraction as is I am adding a html call for each posts.
See `HashtagPageParser`
