### PR TITLE
fix: issue with cookies in login from Europe

### DIFF
--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -772,6 +772,11 @@ class FacebookScraper:
 
     def login(self, email: str, password: str):
         response = self.get(self.base_url)
+
+        cookies_values = re.findall(r'js_datr","([^"]+)', response.html.html)
+        if len(cookies_values) == 1:
+            self.session.cookies.set("datr", cookies_values[0])
+
         response = self.submit_form(
             response, {"email": email, "pass": password, "_fb_noscript": None}
         )


### PR DESCRIPTION
[#599 ](https://github.com/kevinzg/facebook-scraper/issues/599) you try to connect to Facebook from Europe, cookies can't not automatically accepted as in US.
I've added a preliminary control if the source of the page has "js_datr" cookie that is the one that have the value for the real one: "datr".

https://ibb.co/6Xr5xVy This image shows in the right (using Opera's vpn with American ip) automatically has datr cookie and on the right the italian version where you have to accept it.