### PR TITLE
fix extraction of reactions from comments

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -886,10 +886,68 @@ class PostExtractor:
             logger.debug(f"Fetching {reaction_url}")
             response = self.request(reaction_url)
             if not reactions or force_parse_HTML:
+                reaction_lookup.update({
+                    '1635855486666999': {
+                        'color': '#2078f4',
+                        'display_name': 'Like',
+                        'is_deprecated': False,
+                        'is_visible': True,
+                        'name': 'like',
+                        'type': 1635855486666999,
+                    },
+                    '613557422527858': {
+                        'color': '#f7b125',
+                        'display_name': 'Care',
+                        'is_deprecated': False,
+                        'is_visible': True,
+                        'name': 'support',
+                        'type': 613557422527858,
+                    },
+                    '1678524932434102': {
+                        'color': '#f33e58',
+                        'display_name': 'Love',
+                        'is_deprecated': False,
+                        'is_visible': True,
+                        'name': 'love',
+                        'type': 1678524932434102,
+                    },
+                    '478547315650144': {
+                        'color': '#f7b125',
+                        'display_name': 'Wow',
+                        'is_deprecated': False,
+                        'is_visible': True,
+                        'name': 'wow',
+                        'type': 478547315650144,
+                    },
+                    '115940658764963': {
+                        'color': '#f7b125',
+                        'display_name': 'Haha',
+                        'is_deprecated': False,
+                        'is_visible': True,
+                        'name': 'haha',
+                        'type': 115940658764963,
+                    },
+                    '908563459236466': {
+                        'color': '#f7b125',
+                        'display_name': 'Sad',
+                        'is_deprecated': False,
+                        'is_visible': True,
+                        'name': 'sorry',
+                        'type': 908563459236466,
+                    },
+                    '444813342392137': {
+                        'color': '#e9710f',
+                        'display_name': 'Angry',
+                        'is_deprecated': False,
+                        'is_visible': True,
+                        'name': 'anger',
+                        'type': 444813342392137,
+                    },
+                })
                 reactions = {}
                 reaction_count = 0
                 for sigil in response.html.find("span[data-sigil='reaction_profile_sigil']"):
-                    k = str(demjson.decode(sigil.attrs.get("data-store"))["reactionType"])
+                    k = str(demjson.decode(sigil.attrs.get("data-store"))["reactionID"])
                     v = sigil.find(
                         "span[data-sigil='reaction_profile_tab_count']", first=True
                     ).text.replace("All ", "")


### PR DESCRIPTION
Fb has changed from reactionType to reactionID and uses different code numbers for the reactions of comments rather than post reactions.
I've checked manually the different reactions numbers and update the dictionary with the new codes.