### PR TITLE
Fix key_error 'id' get_profile

### DIFF
--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -297,6 +297,7 @@ class FacebookScraper:
                 request_url_callback(more_url)
 
     def get_profile(self, account, **kwargs) -> Profile:
+        pid = account
         account = account.replace("profile.php?id=", "")
         result = {}
 
@@ -466,6 +467,10 @@ class FacebookScraper:
                     f'/{account}?v=following', limit=kwargs.get("following"), **kwargs
                 )
             )
+
+        
+        if result.get("id") is None:
+           result["id"] = pid
 
         # Likes
         if result["id"] and kwargs.get("likes"):

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -377,9 +377,7 @@ class FacebookScraper:
         about_url = utils.urljoin(FB_MOBILE_BASE_URL, f'/{account}/about/')
         logger.debug(f"Requesting page from: {about_url}")
         response = self.get(about_url)
-        match = re.search(r'entity_id:(\d+),', response.html.html)
-        with open("a.html","w",encoding="utf8") as file:
-            file.write(response.html.html)
+        match = re.search(r'entity_id:(\d)+', response.html.html)
         if match:
             result["id"] = match.group(1)
         # Profile name is in the title

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -378,6 +378,8 @@ class FacebookScraper:
         logger.debug(f"Requesting page from: {about_url}")
         response = self.get(about_url)
         match = re.search(r'entity_id:(\d+),', response.html.html)
+        with open("a.html","w",encoding="utf8") as file:
+            file.write(response.html.html)
         if match:
             result["id"] = match.group(1)
         # Profile name is in the title

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -377,7 +377,9 @@ class FacebookScraper:
         about_url = utils.urljoin(FB_MOBILE_BASE_URL, f'/{account}/about/')
         logger.debug(f"Requesting page from: {about_url}")
         response = self.get(about_url)
-        match = re.search(r'entity_id:(\d)+', response.html.html)
+        match = re.search(r'entity_id:(\d+),', response.html.html)
+        with open("a.html","w",encoding="utf8") as file:
+            file.write(response.html.html)
         if match:
             result["id"] = match.group(1)
         # Profile name is in the title

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -377,9 +377,7 @@ class FacebookScraper:
         about_url = utils.urljoin(FB_MOBILE_BASE_URL, f'/{account}/about/')
         logger.debug(f"Requesting page from: {about_url}")
         response = self.get(about_url)
-        match = re.search(r'entity_id:(\d+)', response.html.html)
-        with open("a.html","w",encoding="utf8") as file:
-            file.write(response.html.html)
+        match = re.search(r'entity_id:(\d)+', response.html.html)
         if match:
             result["id"] = match.group(1)
         # Profile name is in the title

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -377,7 +377,7 @@ class FacebookScraper:
         about_url = utils.urljoin(FB_MOBILE_BASE_URL, f'/{account}/about/')
         logger.debug(f"Requesting page from: {about_url}")
         response = self.get(about_url)
-        match = re.search(r'entity_id:(\d+),', response.html.html)
+        match = re.search(r'entity_id:(\d+)', response.html.html)
         with open("a.html","w",encoding="utf8") as file:
             file.write(response.html.html)
         if match:


### PR DESCRIPTION
I fixed it by:
file facebook_scraper.py line 380:
match = re.search(r'entity_id:(\d+),', response.html.html)
to
match = re.search(r'entity_id:(\d)+', response.html.html)

*Because facebook-scraper get profile id by regex:
Html text is: entity_id:12334455,...}]
#Old regex; r'entity_id:(\d+),'
#Result: entity_id:12334455,
#But in this case, we have: entity_id:12334455}]
#So we change regex to: r'entity_id:(\d)+'
result: entity_id:12334455