### PR TITLE
Add verification for Suspended account on get requests

### DIFF
--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -862,6 +862,9 @@ class FacebookScraper:
                 "you can't use this feature right now",
                 "you’re temporarily blocked",
             ]
+            if "checkpoint" in response.url:
+                if response.html.find("h1", containing="We suspended your account")
+                    raise exceptions.AccountDisabled("Your Account Has Been Disabled")
             if title:
                 if title.text.lower() in not_found_titles:
                     raise exceptions.NotFound(title.text)

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -949,6 +949,8 @@ class FacebookScraper:
     def is_logged_in(self) -> bool:
         try:
             self.get('https://m.facebook.com/settings')
+            if "checkpoint" in response.url:
+                return False
             return True
         except exceptions.LoginRequired:
             return False

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -863,7 +863,7 @@ class FacebookScraper:
                 "you’re temporarily blocked",
             ]
             if "checkpoint" in response.url:
-                if response.html.find("h1", containing="We suspended your account")
+                if response.html.find("h1", containing="We suspended your account"):
                     raise exceptions.AccountDisabled("Your Account Has Been Disabled")
             if title:
                 if title.text.lower() in not_found_titles:

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -952,7 +952,7 @@ class FacebookScraper:
     def is_logged_in(self) -> bool:
         try:
             self.get('https://m.facebook.com/settings')
-            if "checkpoint" in response.url:
+            if "checkpoint" in self.url:
                 return False
             return True
         except exceptions.LoginRequired:

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -952,8 +952,6 @@ class FacebookScraper:
     def is_logged_in(self) -> bool:
         try:
             self.get('https://m.facebook.com/settings')
-            if "checkpoint" in self.url:
-                return False
             return True
         except exceptions.LoginRequired:
             return False


### PR DESCRIPTION
Adding validation to check for account getting suspended.

I suspect that if we hit the page 'checkpoint', regardless if the Suspended message is writen or not, the account has been suspended. We should probably raise an error regardless.
