### PR TITLE
Added functionality to use persistent session

### DIFF
--- a/facebook_scraper/__init__.py
+++ b/facebook_scraper/__init__.py
@@ -5,11 +5,12 @@ import logging
 import pathlib
 import sys
 import warnings
+import pickle
 from typing import Any, Dict, Iterator, Optional, Set, Union
 
 from requests.cookies import cookiejar_from_dict
 
-from .constants import DEFAULT_REQUESTS_TIMEOUT
+from .constants import DEFAULT_REQUESTS_TIMEOUT, DEFAULT_COOKIES_FILE_PATH
 from .facebook_scraper import FacebookScraper
 from .fb_types import Credentials, Post, RawPost, Profile
 from .utils import html_element_to_string, parse_cookie_file
@@ -299,7 +300,6 @@ def get_posts_by_search(
     credentials: Optional[Credentials] = None,
     **kwargs,
 ) -> Iterator[Post]:
-
     """Get posts by searching all of Facebook
     Args:
         word (str): The word for searching posts.
@@ -515,6 +515,41 @@ def enable_logging(level=logging.DEBUG):
 
     logger.addHandler(handler)
     logger.setLevel(level)
+
+
+def use_persistent_session(email: str, password: str, cookies_file_path=DEFAULT_COOKIES_FILE_PATH):
+    """Login persistently to Facebook and save cookies to a file (default: ".fb-cookies.pckl"). This is highly recommended if you want to scrape several times a day because it will keep your session alive instead of logging in every time (which can be flagged as suspicious by Facebook).
+
+    Args:
+        email (str): email address to login.
+        password (str): password to login.
+        cookies_file_path (str, optional): path to the file in which to save cookies. Defaults to ".fb-cookies.pckl".
+
+    Raises:
+        exceptions.InvalidCredentials: if the credentials are invalid.
+
+    Returns:
+        Boolean: True if the login was successful, False otherwise.
+    """
+    try:
+        with open(cookies_file_path, "rb") as f:
+            cookies = pickle.load(f)
+        logger.debug("Loaded cookies from %s", cookies_file_path)
+    except FileNotFoundError:
+        logger.error("No cookies file found at %s", cookies_file_path)
+        cookies = None
+    try:
+        if not cookies:
+            raise exceptions.InvalidCookies()
+        set_cookies(cookies)
+        logger.debug("Successfully logged in with cookies")
+    except exceptions.InvalidCookies:
+        logger.exception("Invalid cookies, trying to login with credentials")
+        cookies = _scraper.login(email, password)
+        with open(cookies_file_path, "wb") as f:
+            pickle.dump(cookies, f)
+        set_cookies(cookies)
+        logger.debug("Successfully logged in with credentials")
 
 
 # Disable logging by default

--- a/facebook_scraper/constants.py
+++ b/facebook_scraper/constants.py
@@ -5,3 +5,5 @@ FB_MBASIC_BASE_URL = 'https://mbasic.facebook.com/'
 
 DEFAULT_REQUESTS_TIMEOUT = 30
 DEFAULT_PAGE_LIMIT = 10
+
+DEFAULT_COOKIES_FILE_PATH = '.fb-cookies.pckl'


### PR DESCRIPTION
Hi guys, I'm submitting this small change to allow using cookies and credentials simultaneously.

To my knowledge:
> If you want to scrap with a logged account, you can either give your credentials or your cookies.

2 issues quickly arise if you use a logged account for a long period of time (e.g. scrapping things on a private FB group every day) :
- If you use the `credentials` property, Facebook will quickly flag you as a suspect as you log in too often, making you suspicious.
- If you use the `cookies`  property, you must manually refresh the content of the cookies to avoid the expiration of your session.

The `use_persistent_session`  method allows you to log in before querying private information by only providing your credentials. Under the hood, the cookies are automatically stored, used, and refreshed to avoid as far as possible using your credentials and being flagged as suspicious by Facebook.

Usage:

```python3
>>> facebook_scraper.use_persistent_session(FB_USERNAME, FB_PASSWORD)

>>> for post in get_posts('private_group', pages=1):
...           print(post['text'])
...
Lorem ipsum dolor sit amet consectetur adipisicing elit.
Maxime mollitia molestiae quas vel sint commodi (...)
```

I remain open to all discussions 😄.