### PR TITLE
Add comment_reaction_count also when comment_reactors opt is False

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -1089,6 +1089,13 @@ class PostExtractor:
                 reactions = self.extract_reactions(comment_id, force_parse_HTML=True)
                 if comment_reactors_opt != "generator":
                     reactions["reactors"] = utils.safe_consume(reactions.get("reactors", []))
+        else:
+            reactions_count = comment.find('span._14va', first=True)
+            if reactions_count and len(reactions_count.text) > 0:
+                reactions_count = reactions_count.text
+            else:
+                reactions_count = None
+            reactions.update({"reaction_count": reactions_count})
 
         return {
             "comment_id": comment_id,


### PR DESCRIPTION
The information on the total reactions to the comment can be useful even without having all the reactors or distinct reactions.