### PR TITLE
fix text for posts with photo

### DIFF
--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -274,6 +274,9 @@ class PostExtractor:
         has_more = self.more_url_regex.search(element.html)
         if has_more and self.full_post_html:
             element = self.full_post_html.find('.story_body_container', first=True)
+            if not element and self.full_post_html.find("div.msg", first=True):
+                text = self.full_post_html.find("div.msg", first=True).text
+                return {"text": text, "post_text": text}
 
         nodes = element.find('p, header, span[role=presentation]')
         if nodes and len(nodes) > 1:


### PR DESCRIPTION
Fix extraction of text from post with photos and long text (therefore with the more button) during get_posts returns an identifier to None. The resulting text will be null instead of the real content.