### PR TITLE
Handle translation for shared and user text, split into separate properties.

### DIFF
--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -757,10 +757,10 @@ class FacebookScraper:
         except:
             result["about"] = None
 
-        url = members.find("a", first=True).attrs.get("href")
-        logger.debug(f"Requesting page from: {url}")
-
         try:
+            url = members.find("a", first=True).attrs.get("href")
+            logger.debug(f"Requesting page from: {url}")
+
             resp = self.get(url).html
             url = resp.find("a[href*='listType=list_admin_moderator']", first=True)
             if kwargs.get("admins", True):


### PR DESCRIPTION
Make the original text the default "text" property and split that into "post" and "shared". Since the scraper recommends using US locale it gives wrong texts for non-english posts.
[Post,Shared] Text is original language text.
Translated [Post,Shared] Text is facebooks translation. 
Original text is also copied to "original_text" to ensure backward compatability.

Code looks for several story_body_containers and handles them one at a time.

Should the properties be copied to the default data model?