### PR TITLE
Add default for 'matching' argument

### DIFF
--- a/facebook_scraper/__init__.py
+++ b/facebook_scraper/__init__.py
@@ -466,7 +466,7 @@ def write_posts_to_csv(
                     output_file.write(",")
             match = None
             if post["text"]:
-                match = re.search(kwargs.get("matching"), post["text"], flags=re.IGNORECASE)
+                match = re.search(kwargs.get("matching", '.+'), post["text"], flags=re.IGNORECASE)
                 if kwargs.get("not_matching") and re.search(
                     kwargs.get("not_matching"), post["text"], flags=re.IGNORECASE
                 ):


### PR DESCRIPTION
Hi,

I tried to use `write_posts_to_csv` recently and got an error message because I was missing the "matching" argument. I wanted to keep all the posts so I ended up using a regex code to match anything.

But it seemed a bit unnecessary so I looked at the code and it seems the CLI already has a [default](https://github.com/kevinzg/facebook-scraper/blob/30a1f958cab850de6c2b06040523b4ddec26422c/facebook_scraper/__main__.py#L90).

So I added the default in the function itself.

Some follow-up questions to improve on the PR:
- Should we remove the default value in the CLI parser? It's now redundant.
- Is `.+` the best regex to match absolutely anything? It seems like [it could ignore newlines](https://stackoverflow.com/questions/6711971/regular-expressions-match-anything), which might not be a possible case for Facebook post's text?